### PR TITLE
Passing empty array instead of null to Dump

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -36,7 +36,7 @@ if (!function_exists('dump')) {
     function dump()
     {
         array_map(function ($x) {
-            $string = (new Dump(null, true))->variable($x);
+            $string = (new Dump([], true))->variable($x);
 
             echo (PHP_SAPI == 'cli' ? strip_tags($string) . PHP_EOL : $string);
 


### PR DESCRIPTION
Fix for phalcon 4 and php 72